### PR TITLE
Go: Fix `Size_` and make import order deterministic (#118)

### DIFF
--- a/go/generated/code.vegaprotocol.io/vega/proto/api/trading.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/api/trading.validator.pb.go
@@ -6,8 +6,9 @@ package api
 import (
 	fmt "fmt"
 	math "math"
-	proto "github.com/golang/protobuf/proto"
+
 	_ "code.vegaprotocol.io/vega/proto"
+	proto "github.com/golang/protobuf/proto"
 	_ "github.com/mwitkow/go-proto-validators"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/go/generated/code.vegaprotocol.io/vega/proto/assets.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/assets.validator.pb.go
@@ -6,6 +6,7 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/go/generated/code.vegaprotocol.io/vega/proto/chain_events.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/chain_events.validator.pb.go
@@ -6,6 +6,7 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/go/generated/code.vegaprotocol.io/vega/proto/events.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/events.validator.pb.go
@@ -6,6 +6,7 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/go/generated/code.vegaprotocol.io/vega/proto/governance.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/governance.validator.pb.go
@@ -6,6 +6,7 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	_ "github.com/mwitkow/go-proto-validators"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"

--- a/go/generated/code.vegaprotocol.io/vega/proto/markets.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/markets.validator.pb.go
@@ -6,6 +6,7 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	_ "github.com/mwitkow/go-proto-validators"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"

--- a/go/generated/code.vegaprotocol.io/vega/proto/vega.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/proto/vega.validator.pb.go
@@ -6,9 +6,10 @@ package proto
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
-	_ "github.com/mwitkow/go-proto-validators"
 	_ "github.com/golang/protobuf/ptypes/wrappers"
+	_ "github.com/mwitkow/go-proto-validators"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )
 
@@ -216,8 +217,8 @@ func (this *OrderSubmission) Validate() error {
 	if this.PartyId == "" {
 		return github_com_mwitkow_go_proto_validators.FieldError("PartyId", fmt.Errorf(`value '%v' must not be an empty string`, this.PartyId))
 	}
-	if !(this.Size_ > 0) {
-		return github_com_mwitkow_go_proto_validators.FieldError("Size_", fmt.Errorf(`value '%v' must be greater than '0'`, this.Size_))
+	if !(this.Size > 0) {
+		return github_com_mwitkow_go_proto_validators.FieldError("Size_", fmt.Errorf(`value '%v' must be greater than '0'`, this.Size))
 	}
 	if _, ok := Side_name[int32(this.Side)]; !ok {
 		return github_com_mwitkow_go_proto_validators.FieldError("Side", fmt.Errorf(`value '%v' must be a valid Side field`, this.Side))

--- a/go/generated/code.vegaprotocol.io/vega/tm/replay.validator.pb.go
+++ b/go/generated/code.vegaprotocol.io/vega/tm/replay.validator.pb.go
@@ -6,6 +6,7 @@ package tm
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/go/generated/github.com/mwitkow/go-proto-validators/validator.validator.pb.go
+++ b/go/generated/github.com/mwitkow/go-proto-validators/validator.validator.pb.go
@@ -6,6 +6,7 @@ package validator
 import (
 	fmt "fmt"
 	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	_ "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )

--- a/go/post-generate.sh
+++ b/go/post-generate.sh
@@ -1,5 +1,42 @@
 #!/usr/bin/env bash
 
+set -e
+
+if ! command -v goimports 1>/dev/null ; then
+	echo "Please install goimports."
+	exit 1
+fi
+
 go_generated_dir="${GO_GENERATED_DIR:?}"
 
 find "$go_generated_dir" -name '*.go' -print0 | xargs -0r sed --in-place -re 's#[ \t]+$##'
+
+# AWK script to remove all blank lines in the "imports" section of a golang source file.
+awkscript="$(mktemp)"
+cat >"$awkscript" <<EOF
+BEGIN {
+	IMP=0
+}
+IMP==1 && /^\\)$/ {
+	IMP=0
+}
+(IMP==1 && !/^$/) || IMP==0 {
+	print
+}
+IMP==0 && /^import \\($/ {
+	IMP=1
+}
+EOF
+
+find "$go_generated_dir" -name '*.validator.pb.go' | sort | while read -r valpbgo
+do
+	# Rename Size_ back to Size. See https://github.com/mwitkow/go-proto-validators/issues/51
+	sed -i -re 's/this\.Size_/this.Size/' "$valpbgo"
+
+	# Make the import list order deterministic.
+	f="$(mktemp)"
+	awk -f "$awkscript" <"$valpbgo" >"$f"
+	mv "$f" "$valpbgo"
+	goimports -w "$valpbgo"
+done
+rm -f "$awkscript"


### PR DESCRIPTION
This PR:
- renames `Size_` back to `Size` (ref https://github.com/mwitkow/go-proto-validators/issues/51)
- makes the import list order deterministic (with `awk` and `goimports`)

Closes #118.